### PR TITLE
Promises

### DIFF
--- a/BuckoNetworking.xcodeproj/project.pbxproj
+++ b/BuckoNetworking.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		6ABB45021EF86C0900E344AF /* DecodableEndpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7D02921E4CC12900E66FD0 /* DecodableEndpoint.swift */; };
 		6ABB45041EF86DE200E344AF /* BuckoNetworking.h in Headers */ = {isa = PBXBuildFile; fileRef = 6A7D02751E4CBEFC00E66FD0 /* BuckoNetworking.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		6AEC6FDE1E84B05500BBD3F7 /* Alamofire.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AEC6FDC1E84B05500BBD3F7 /* Alamofire.framework */; };
+		6AFA9DED1FF68A0D00FDC188 /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AFA9DEC1FF68A0D00FDC188 /* PromiseKit.framework */; };
+		6AFA9DEF1FF68A3400FDC188 /* PromiseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AFA9DEE1FF68A3400FDC188 /* PromiseKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -60,6 +62,8 @@
 		6ABB44FB1EF8661100E344AF /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/Mac/Alamofire.framework; sourceTree = "<group>"; };
 		6AEC6FDB1E84B05500BBD3F7 /* SwiftyJSON.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftyJSON.framework; path = Carthage/Build/iOS/SwiftyJSON.framework; sourceTree = "<group>"; };
 		6AEC6FDC1E84B05500BBD3F7 /* Alamofire.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Alamofire.framework; path = Carthage/Build/iOS/Alamofire.framework; sourceTree = "<group>"; };
+		6AFA9DEC1FF68A0D00FDC188 /* PromiseKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PromiseKit.framework; path = Carthage/Build/iOS/PromiseKit.framework; sourceTree = "<group>"; };
+		6AFA9DEE1FF68A3400FDC188 /* PromiseKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PromiseKit.framework; path = Carthage/Build/Mac/PromiseKit.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -67,6 +71,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6AFA9DED1FF68A0D00FDC188 /* PromiseKit.framework in Frameworks */,
 				6AEC6FDE1E84B05500BBD3F7 /* Alamofire.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -83,6 +88,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				6AFA9DEF1FF68A3400FDC188 /* PromiseKit.framework in Frameworks */,
 				6ABB44FD1EF8661100E344AF /* Alamofire.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -152,6 +158,8 @@
 		6A7D02D41E4CC5E900E66FD0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				6AFA9DEC1FF68A0D00FDC188 /* PromiseKit.framework */,
+				6AFA9DEE1FF68A3400FDC188 /* PromiseKit.framework */,
 				6ABB44FA1EF8661100E344AF /* SwiftyJSON.framework */,
 				6ABB44FB1EF8661100E344AF /* Alamofire.framework */,
 				6AEC6FDB1E84B05500BBD3F7 /* SwiftyJSON.framework */,

--- a/BuckoNetworking/Bucko.swift
+++ b/BuckoNetworking/Bucko.swift
@@ -15,18 +15,6 @@ public protocol BuckoErrorHandler: class {
 
 public typealias BuckoResponseClosure = ((DataResponse<Any>) -> Void)
 public typealias BuckoDataResponseClosure = ((DataResponse<Data>) -> Void)
-@available(*, deprecated, message: "Use HTTPMethod instead")
-public typealias HttpMethod = HTTPMethod
-@available(*, deprecated, message: "Use HTTPHeaders instead")
-public typealias HttpHeaders = HTTPHeaders
-@available(*, deprecated, message: "Use ParameterEncoding instead")
-public typealias Encoding = ParameterEncoding
-@available(*, deprecated, message: "Use URLEncoding instead")
-public typealias UrlEncoding = URLEncoding
-@available(*, deprecated, message: "Use JSONEncoding instead")
-public typealias JsonEncoding = JSONEncoding
-@available(*, deprecated, message: "Use Parameters instead")
-public typealias Body = Parameters
 
 public struct Bucko {
   /**
@@ -157,21 +145,21 @@ public struct Bucko {
   }
   
   public func request(endpoint: Endpoint) -> Promise<DataResponse<Any>> {
-    return Promise { fullfill, reject in
+    return Promise { seal in
       request(endpoint: endpoint) { response in
         
         if response.result.isSuccess {
-          fullfill(response)
+          seal.fulfill(response)
         } else {
           if let responseError = response.result.value {
             do {
               let json = try JSONSerialization.data(withJSONObject: responseError, options: [])
-              reject(BuckoError(apiError: json))
+              seal.reject(BuckoError(apiError: json))
             } catch {
-              reject(response.result.error!)
+              seal.reject(response.result.error!)
             }
           } else {
-            reject(response.result.error!)
+            seal.reject(response.result.error!)
           }
         }
       }
@@ -179,17 +167,17 @@ public struct Bucko {
   }
   
   public func requestData(endpoint: Endpoint) -> Promise<Data> {
-    return Promise { fulfill, reject in
+    return Promise { seal in
       requestData(endpoint: endpoint) { response in
         
         if response.result.isSuccess {
-          fulfill(response.result.value!)
+          seal.fulfill(response.result.value!)
         } else {
           
           if let responseError = response.result.value {
-            reject(BuckoError(apiError: responseError))
+            seal.reject(BuckoError(apiError: responseError))
           } else {
-            reject(response.result.error!)
+            seal.reject(response.result.error!)
           }
         }
       }

--- a/BuckoNetworking/Bucko.swift
+++ b/BuckoNetworking/Bucko.swift
@@ -155,4 +155,44 @@ public struct Bucko {
     print(request.description)
     return request
   }
+  
+  public func request(endpoint: Endpoint) -> Promise<DataResponse<Any>> {
+    return Promise { fullfill, reject in
+      request(endpoint: endpoint) { response in
+        
+        if response.result.isSuccess {
+          fullfill(response)
+        } else {
+          if let responseError = response.result.value {
+            do {
+              let json = try JSONSerialization.data(withJSONObject: responseError, options: [])
+              reject(BuckoError(apiError: json))
+            } catch {
+              reject(response.result.error!)
+            }
+          } else {
+            reject(response.result.error!)
+          }
+        }
+      }
+    }
+  }
+  
+  public func requestData(endpoint: Endpoint) -> Promise<Data> {
+    return Promise { fulfill, reject in
+      requestData(endpoint: endpoint) { response in
+        
+        if response.result.isSuccess {
+          fulfill(response.result.value!)
+        } else {
+          
+          if let responseError = response.result.value {
+            reject(BuckoError(apiError: responseError))
+          } else {
+            reject(response.result.error!)
+          }
+        }
+      }
+    }
+  }
 }

--- a/BuckoNetworking/BuckoError.swift
+++ b/BuckoNetworking/BuckoError.swift
@@ -6,11 +6,10 @@
 //  Copyright © 2017 Teeps. All rights reserved.
 //
 
-import Foundation.NSError
+private let buckoErrorData = "BuckoErrorData"
 
 public final class BuckoError: NSError {
-  
-  fileprivate enum Code: Int {
+  private enum Code: Int {
     case api = 1
     case validation
     case service // an error caused by a third party service
@@ -19,13 +18,17 @@ public final class BuckoError: NSError {
     case unknown
   }
   
-  fileprivate static var domain: String {
+  private static var domain: String {
     return Bundle.main.bundleIdentifier!
   }
   
   // MARK: - Convenience error initializers
   convenience init(apiError reason: String, description: String? = nil) {
     self.init(code: .api, reason: reason, description: description)
+  }
+  
+  convenience init(apiError data: Data) {
+    self.init(code: .api, reason: "API Error", description: nil, data: data)
   }
   
   convenience init(validationError reason: String, description: String? = nil) {
@@ -48,11 +51,16 @@ public final class BuckoError: NSError {
     self.init(code: .auth, reason: reason, description: description)
   }
   
-  fileprivate convenience init(code: Code, reason: String, description: String? = nil) {
-    self.init(domain: BuckoError.domain, code: code.rawValue, userInfo: [
-      NSLocalizedFailureReasonErrorKey: reason,
-      NSLocalizedDescriptionKey: description ?? reason
-      ])
+  private convenience init(code: Code, reason: String, description: String? = nil, data: Data? = nil) {
+    self.init(
+      domain: BuckoError.domain,
+      code: code.rawValue,
+      userInfo: [
+        NSLocalizedFailureReasonErrorKey: reason,
+        NSLocalizedDescriptionKey: description ?? reason,
+        buckoErrorData: data ?? NSNull()
+      ]
+    )
   }
   
   // MARK: - Common errors
@@ -63,5 +71,20 @@ public final class BuckoError: NSError {
   static func unknown() -> BuckoError {
     return BuckoError(code: .unknown, reason: "An unknown error occurred")
   }
+}
+
+public extension Error {
+  var data: Data? {
+    let error = self as NSError
+    guard let data = error.userInfo[buckoErrorData] as? Data else { return nil }
+    
+    return data
+  }
   
+  var json: Any? {
+    guard let data = data,
+      let json = try? JSONSerialization.jsonObject(with: data, options: []) else { return nil }
+    
+    return json
+  }
 }

--- a/BuckoNetworking/BuckoNetworking.h
+++ b/BuckoNetworking/BuckoNetworking.h
@@ -8,6 +8,7 @@
 
 @import Foundation;
 @import Alamofire;
+@import PromiseKit;
 
 //! Project version number for BuckoNetworking.
 FOUNDATION_EXPORT double BuckoNetworkingVersionNumber;

--- a/BuckoNetworking/Protocols/DecodableEndpoint.swift
+++ b/BuckoNetworking/Protocols/DecodableEndpoint.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2017 Teeps. All rights reserved.
 //
 
-import Alamofire
-
 public protocol DecodableEndpoint: Endpoint {
   associatedtype ResponseType: Decodable
 }
@@ -33,5 +31,14 @@ public extension DecodableEndpoint {
     }
     
     return request
+  }
+  
+  public func request() -> Promise<ResponseType> {
+    return Bucko.shared.requestData(endpoint: self).then { data in
+      return Promise { fullfill, _ in
+        let result = try JSONDecoder().decode(ResponseType.self, from: data)
+        fullfill(result)
+      }
+    }
   }
 }

--- a/BuckoNetworking/Protocols/DecodableEndpoint.swift
+++ b/BuckoNetworking/Protocols/DecodableEndpoint.swift
@@ -35,9 +35,9 @@ public extension DecodableEndpoint {
   
   public func request() -> Promise<ResponseType> {
     return Bucko.shared.requestData(endpoint: self).then { data in
-      return Promise { fullfill, _ in
+      return Promise { seal in
         let result = try JSONDecoder().decode(ResponseType.self, from: data)
-        fullfill(result)
+        seal.fulfill(result)
       }
     }
   }

--- a/BuckoNetworking/Protocols/Endpoint.swift
+++ b/BuckoNetworking/Protocols/Endpoint.swift
@@ -87,9 +87,9 @@ public extension Endpoint {
   
   public func request<T: Decodable>(responseType: T.Type) -> Promise<T> {
     return Bucko.shared.requestData(endpoint: self).then { data in
-      return Promise { fullfill, _ in
+      return Promise { seal in
         let result = try JSONDecoder().decode(T.self, from: data)
-        fullfill(result)
+        seal.fulfill(result)
       }
     }
   }

--- a/BuckoNetworking/Protocols/Endpoint.swift
+++ b/BuckoNetworking/Protocols/Endpoint.swift
@@ -84,4 +84,13 @@ public extension Endpoint {
     
     return request
   }
+  
+  public func request<T: Decodable>(responseType: T.Type) -> Promise<T> {
+    return Bucko.shared.requestData(endpoint: self).then { data in
+      return Promise { fullfill, _ in
+        let result = try JSONDecoder().decode(T.self, from: data)
+        fullfill(result)
+      }
+    }
+  }
 }

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-github "Alamofire/Alamofire" ~> 4.4
-github "mxcl/PromiseKit" ~> 4.5
+github "Alamofire/Alamofire" ~> 4.6.0
+github "mxcl/PromiseKit" ~> 6.1.0

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "Alamofire/Alamofire" ~> 4.4
-
+github "mxcl/PromiseKit" ~> 4.5

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,2 @@
 github "Alamofire/Alamofire" "4.6.0"
+github "mxcl/PromiseKit" "4.5.0"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
 github "Alamofire/Alamofire" "4.6.0"
-github "mxcl/PromiseKit" "4.5.0"
+github "mxcl/PromiseKit" "6.1.0"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ After developing a number of applications, we noticed that everyone's networking
 ### Dependencies
 ------
 
-We ended up going with [Alamofire](https://github.com/Alamofire/Alamofire) instead of `URLSession` for a few reasons. Alamofire is asynchronous by nature, has session management, reduces boilerplate code, and is very easy to use.
+* [Alamofire](https://github.com/Alamofire/Alamofire) - We ended up going with Alamofire instead of `URLSession` for a few reasons. Alamofire is asynchronous by nature, has session management, reduces boilerplate code, and is very easy to use.
+
+* [PromiseKit](https://github.com/mxcl/PromiseKit) - We use Promises because they simplify asynchronous programming and separate successful and failed responses, allowing you to focus on each part in their own individual closures.
 
 ### Installation
 ------
@@ -33,7 +35,7 @@ github "teepsllc/BuckoNetworking", ~> 2.0.0
 ```
 
 1. Run `carthage update --platform iOS --no-use-binaries` to build the framework.
-1. On your application targets’ “General” settings tab, in the “Linked Frameworks and Libraries” section, drag and drop `BuckoNetworking.framework` from the [Carthage/Build]() folder on disk. You will also need to drag `Alamofire.framework` into your project.
+1. On your application targets’ “General” settings tab, in the “Linked Frameworks and Libraries” section, drag and drop `BuckoNetworking.framework` from the [Carthage/Build]() folder on disk. You will also need to drag `Alamofire.framework` and `PromiseKit.framework` into your project.
 1. On your application targets’ “Build Phases” settings tab, click the “+” icon and choose “New Run Script Phase”. Create a Run Script in which you specify your shell (ex: `/bin/sh`), add the following contents to the script area below the shell:
 
   ```sh
@@ -45,6 +47,7 @@ github "teepsllc/BuckoNetworking", ~> 2.0.0
   ```
   $(SRCROOT)/Carthage/Build/iOS/BuckoNetworking.framework
   $(SRCROOT)/Carthage/Build/iOS/Alamofire.framework
+  $(SRCROOT)/Carthage/Build/iOS/PromiseKit.framework
   ```
   This script works around an [App Store submission bug](http://www.openradar.me/radar?id=6409498411401216) triggered by universal binaries and ensures that necessary bitcode-related files and dSYMs are copied when archiving.
 
@@ -91,10 +94,7 @@ $ pod install
 
 Swift 4 introduced the Codable protocol and the `DecodableEndpoint` in BuckoNetworking uses this to the max!
 
-
 ```swift
-import BuckoNetworking
-
 struct User: Decodable {
   var name: String
   var phoneNumber: String
@@ -107,17 +107,29 @@ struct User: Decodable {
 
 struct UserService: DecodableEndpoint {
   typealias ResponseType = User
-  var baseURL: String = "https://example.com/"
-  var path: String = "users/"
-  var method: HTTPMethod = .post
-  var parameters: Parameters {
-      var parameters = Parameters()
-      parameters["first_name"] = "Bucko"
-      return parameters
-  }
-  var headers: HttpHeaders = ["Authorization" : "Bearer SOME_TOKEN"]
+  var baseURL: String { return "https://example.com" }
+  var path: String { return "/users" }
+  var method: HTTPMethod { return .get }
+  var body: Parameters { return Parameters() }
+  var headers: HTTPHeaders { return HTTPHeaders() }
 }
 
+UserService().request().then { users in
+  // Do something with users
+  users.count
+}.catch { error in
+
+  if let json = error.json {
+    // Use json
+  } else {
+    // Some other error occurred that doesn't include json
+  }
+}
+```
+
+If you don't want to use Promises, BuckoNetworking also provides normal closures:
+
+```swift
 UserService().request { (user, error) in
   guard let user = user else {
     // Do Error
@@ -143,6 +155,20 @@ enum UserService: Endpoint {
   var headers: HTTPHeaders { return HTTPHeaders() }
 }
 
+// Use your Endpoint
+UserService.index.request(responseType: [User].self).then { users in
+  // Do something with users
+  users.count
+}.catch { error in
+
+  if let json = error.json {
+    // Use json
+  } else {
+    // Some other error occurred that doesn't include json
+  }
+}
+
+// Or without Promises
 UserService.index.request(responseType: [User].self) { (users, error) in
   guard let users = users else {
     // Do Error
@@ -163,7 +189,7 @@ If you don't want to use `Codable`, you can instead use the `Endpoint` protocol,
 ```swift
 import BuckoNetworking
 
-// Create an endpoint
+// Create an Endpoint
 struct UserCreateService: Endpoint {
     var baseURL: String = "https://example.com/"
     var path: String = "users/"
@@ -176,11 +202,18 @@ struct UserCreateService: Endpoint {
     var headers: HttpHeaders = ["Authorization" : "Bearer SOME_TOKEN"]
 }
 
-// Use your endpoint
+// Use your Endpoint
+Bucko.shared.request(UserCreateService()).then { response in
+  // Response successful!
+}.catch { error in
+  //  Failure
+}
+
+// Or without Promises
 Bucko.shared.request(UserCreateService()) { response in
   if response.result.isSuccess {
     // Response successful!
-    let json = Json(response.result.value!)
+    // Convert `response.result.value!` to JSON
   } else {
     // Failure
   }
@@ -193,7 +226,7 @@ Bucko.shared.request(UserCreateService()) { response in
 ```swift
 import BuckoNetworking
 
-// Create an endpoint
+// Create an Endpoint
 enum UserService {
     case getUsers
     case getUser(id: String)
@@ -242,11 +275,18 @@ extension UserService: Endpoint {
     }
 }
 
-// Use your endpoint
+// Use your Endpoint
+Bucko.shared.request(UserService.getUser(id: "1")).then { response in
+  // Response successful!
+}.catch { error in
+  //  Failure
+}
+
+// Or without Promises
 Bucko.shared.request(UserService.getUser(id: "1")) { response in
   if response.result.isSuccess {
     // Response successful!
-    let json = Json(response.result.value!)
+    // Convert `response.result.value!` to JSON
   } else {
     // Failure
   }


### PR DESCRIPTION
This PR adds Promises to Bucko.

```swift
struct User: Decodable {
  var name: String
  var phoneNumber: String
  
  enum CodingKeys: String, CodingKey {
    case name
    case phoneNumber = "phone_number"
  }
}

struct UserService: DecodableEndpoint {
  typealias ResponseType = User
  var baseURL: String { return "https://example.com" }
  var path: String { return "/users" }
  var method: HTTPMethod { return .get }
  var body: Parameters { return Parameters() }
  var headers: HTTPHeaders { return HTTPHeaders() }
}

// You can now use:

Bucko.shared.request(UserService()).then { user in
  // Do something with user
}.catch { error in
  // Do something with error
}

// or

UserService().request().then { user in
  // Do something with user
}.catch { error in
  // Do something with error
}
```

Enums still work as well:

```swift
enum UserService: Endpoint {
  case index

  var baseURL: String { return "https://example.com" }
  var path: String { return "/users" }
  var method: HTTPMethod { return .get }
  var body: Parameters { return Parameters() }
  var headers: HTTPHeaders { return HTTPHeaders() }
}

// Use your Endpoint
UserService.index.request(responseType: [User].self).then { users in
  // Do something with users
}.catch { error in
 // Do something with error
}
```